### PR TITLE
Fixed method lookup for pushUniqueWithGuid

### DIFF
--- a/lib/backburner/queue.js
+++ b/lib/backburner/queue.js
@@ -43,7 +43,7 @@ Queue.prototype = {
   targetQueue: function(targetQueue, target, method, args, stack) {
     var queue = this._queue;
 
-    for (var i = 0, l = targetQueue.length; i < l; i += 4) {
+    for (var i = 0, l = targetQueue.length; i < l; i += 2) {
       var currentMethod = targetQueue[i];
       var currentIndex  = targetQueue[i + 1];
 

--- a/tests/queue_push_unique_test.js
+++ b/tests/queue_push_unique_test.js
@@ -161,3 +161,25 @@ test("pushUnique: 1 target, 1 diffe`rent methods called twice (GUID_KEY)", funct
   deepEqual(target1fooWasCalled[0], ['b']);
 });
 
+test("pushUnique: 1 target, 2 different methods, second one called twice (GUID_KEY)", function() {
+  var queue = new Queue("foo", {}, { GUID_KEY: 'GUID_KEY' });
+  var target1barWasCalled = [];
+  var target1 = {
+    GUID_KEY: 'target1',
+    foo: function() {
+    },
+    bar: function() {
+      target1barWasCalled.push(slice.call(arguments));
+    }
+  };
+
+  queue.pushUnique(target1, target1.foo);
+  queue.pushUnique(target1, target1.bar, ['a']);
+  queue.pushUnique(target1, target1.bar, ['b']);
+
+  deepEqual(target1barWasCalled, []);
+
+  queue.flush();
+
+  deepEqual(target1barWasCalled.length, 1, 'expected: target 1.bar to be called only once');
+});


### PR DESCRIPTION
The lookup logic stepped over every second method entry which
lead to the same method being added multiple times if the
existing entries happen to reside at odd indexes in the
targetQueue array.

Signed-off-by: Christian Gudrian <christian.gudrian@gmx.de>