### PR TITLE
Fixes ebryn/backburner.js#135

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -516,8 +516,8 @@ function updateLaterTimer(backburner, executeAt, wait) {
       clearTimeout(backburner._laterTimer);
 
       if (backburner._laterTimerExpiresAt < n) { // If timer was never triggered
-        // Calculate the left-over wait-time
-        wait = Math.max(0, executeAt - n);
+        // execute it immediately
+        wait = 0;
       }
     }
 

--- a/tests/set-timeout-test.js
+++ b/tests/set-timeout-test.js
@@ -292,7 +292,7 @@ test('setTimeout doesn\'t hang when timeout is unfulfilled', function() { // See
     start();
     equal(called1, 1, 'timeout 1 was called once');
     equal(called2, 1, 'timeout 2 was called once');
-    equal(calls, 1, 'run() was called once'); // both at once
+    equal(calls, 2, 'run() was called twice');
   }, 50);
 });
 

--- a/tests/set-timeout-test.js
+++ b/tests/set-timeout-test.js
@@ -285,7 +285,7 @@ test('setTimeout doesn\'t hang when timeout is unfulfilled', function() { // See
 
   bb.setTimeout(function() {
     called2++;
-  }, 10);
+  }, 50);
 
   stop();
   setTimeout(function () {
@@ -293,7 +293,7 @@ test('setTimeout doesn\'t hang when timeout is unfulfilled', function() { // See
     equal(called1, 1, 'timeout 1 was called once');
     equal(called2, 1, 'timeout 2 was called once');
     equal(calls, 2, 'run() was called twice');
-  }, 50);
+  }, 100);
 });
 
 test('setTimeout with two Backburner instances', function() {


### PR DESCRIPTION
- no longer calculate remaining waiting for timers that are overdue (as @igorT suggested)
- adjusted test setup since run() now runs twice (once for each timer)