### PR TITLE
Throw an error when scheduling a non-existing method

### DIFF
--- a/lib/backburner/deferred-action-queues.js
+++ b/lib/backburner/deferred-action-queues.js
@@ -19,7 +19,7 @@ function noSuchQueue(name) {
 }
 
 function noSuchMethod(name) {
-  throw new Error('You attempted to schedule an action in a queue (' + name + ') for a method doesn\'t exist');
+  throw new Error('You attempted to schedule an action in a queue (' + name + ') for a method that doesn\'t exist');
 }
 
 DeferredActionQueues.prototype = {

--- a/lib/backburner/deferred-action-queues.js
+++ b/lib/backburner/deferred-action-queues.js
@@ -18,6 +18,10 @@ function noSuchQueue(name) {
   throw new Error('You attempted to schedule an action in a queue (' + name + ') that doesn\'t exist');
 }
 
+function noSuchMethod(name) {
+  throw new Error('You attempted to schedule an action in a queue (' + name + ') for a method doesn\'t exist');
+}
+
 DeferredActionQueues.prototype = {
   schedule: function(name, target, method, args, onceFlag, stack) {
     var queues = this.queues;
@@ -25,6 +29,10 @@ DeferredActionQueues.prototype = {
 
     if (!queue) {
       noSuchQueue(name);
+    }
+
+    if (!method) {
+      noSuchMethod(name);
     }
 
     if (onceFlag) {

--- a/tests/defer-once-test.js
+++ b/tests/defer-once-test.js
@@ -53,6 +53,54 @@ test('when passed a target and method name', function() {
   ok(functionWasCalled, 'function was called');
 });
 
+test('throws when passed a null method', function() {
+  expect(1);
+
+  function onError(error) {
+    equal('You attempted to schedule an action in a queue (deferErrors) for a method doesn\'t exist', error.message);
+  }
+
+  var bb = new Backburner(['deferErrors'], {
+    onError: onError
+  });
+
+  bb.run(function() {
+    bb.deferOnce('deferErrors', {zomg: 'hi'}, null);
+  });
+});
+
+test('throws when passed an undefined method', function() {
+  expect(1);
+
+  function onError(error) {
+    equal('You attempted to schedule an action in a queue (deferErrors) for a method doesn\'t exist', error.message);
+  }
+
+  var bb = new Backburner(['deferErrors'], {
+    onError: onError
+  });
+
+  bb.run(function() {
+    bb.deferOnce('deferErrors', {zomg: 'hi'}, undefined);
+  });
+});
+
+test('throws when passed an method name that does not exists on the target', function() {
+  expect(1);
+
+  function onError(error) {
+    equal('You attempted to schedule an action in a queue (deferErrors) for a method doesn\'t exist', error.message);
+  }
+
+  var bb = new Backburner(['deferErrors'], {
+    onError: onError
+  });
+
+  bb.run(function() {
+    bb.deferOnce('deferErrors', {zomg: 'hi'}, 'checkFunction');
+  });
+});
+
 test('when passed a target, method, and arguments', function() {
   expect(5);
 

--- a/tests/defer-once-test.js
+++ b/tests/defer-once-test.js
@@ -33,6 +33,26 @@ test('when passed a target and method', function() {
   ok(functionWasCalled, 'function was called');
 });
 
+test('when passed a target and method name', function() {
+  expect(2);
+
+  var bb = new Backburner(['one']);
+  var functionWasCalled = false;
+  var targetObject = {
+    zomg: 'hi',
+    checkFunction: function() {
+      equal(this.zomg, 'hi', 'the target was properly set');
+      functionWasCalled = true;
+    }
+  };
+
+  bb.run(function() {
+    bb.deferOnce('one', targetObject, 'checkFunction');
+  });
+
+  ok(functionWasCalled, 'function was called');
+});
+
 test('when passed a target, method, and arguments', function() {
   expect(5);
 

--- a/tests/defer-once-test.js
+++ b/tests/defer-once-test.js
@@ -57,7 +57,7 @@ test('throws when passed a null method', function() {
   expect(1);
 
   function onError(error) {
-    equal('You attempted to schedule an action in a queue (deferErrors) for a method doesn\'t exist', error.message);
+    equal('You attempted to schedule an action in a queue (deferErrors) for a method that doesn\'t exist', error.message);
   }
 
   var bb = new Backburner(['deferErrors'], {
@@ -73,7 +73,7 @@ test('throws when passed an undefined method', function() {
   expect(1);
 
   function onError(error) {
-    equal('You attempted to schedule an action in a queue (deferErrors) for a method doesn\'t exist', error.message);
+    equal('You attempted to schedule an action in a queue (deferErrors) for a method that doesn\'t exist', error.message);
   }
 
   var bb = new Backburner(['deferErrors'], {
@@ -89,7 +89,7 @@ test('throws when passed an method name that does not exists on the target', fun
   expect(1);
 
   function onError(error) {
-    equal('You attempted to schedule an action in a queue (deferErrors) for a method doesn\'t exist', error.message);
+    equal('You attempted to schedule an action in a queue (deferErrors) for a method that doesn\'t exist', error.message);
   }
 
   var bb = new Backburner(['deferErrors'], {

--- a/tests/defer-test.js
+++ b/tests/defer-test.js
@@ -58,6 +58,54 @@ test('when passed a target and method name', function() {
   ok(functionWasCalled, 'function was called');
 });
 
+test('throws when passed a null method', function() {
+  expect(1);
+
+  function onError(error) {
+    equal('You attempted to schedule an action in a queue (deferErrors) for a method doesn\'t exist', error.message);
+  }
+
+  var bb = new Backburner(['deferErrors'], {
+    onError: onError
+  });
+
+  bb.run(function() {
+    bb.defer('deferErrors', {zomg: 'hi'}, null);
+  });
+});
+
+test('throws when passed an undefined method', function() {
+  expect(1);
+
+  function onError(error) {
+    equal('You attempted to schedule an action in a queue (deferErrors) for a method doesn\'t exist', error.message);
+  }
+
+  var bb = new Backburner(['deferErrors'], {
+    onError: onError
+  });
+
+  bb.run(function() {
+    bb.defer('deferErrors', {zomg: 'hi'}, undefined);
+  });
+});
+
+test('throws when passed an method name that does not exists on the target', function() {
+  expect(1);
+
+  function onError(error) {
+    equal('You attempted to schedule an action in a queue (deferErrors) for a method doesn\'t exist', error.message);
+  }
+
+  var bb = new Backburner(['deferErrors'], {
+    onError: onError
+  });
+
+  bb.run(function() {
+    bb.defer('deferErrors', {zomg: 'hi'}, 'checkFunction');
+  });
+});
+
 test('when passed a target, method, and arguments', function() {
   expect(5);
 

--- a/tests/defer-test.js
+++ b/tests/defer-test.js
@@ -62,7 +62,7 @@ test('throws when passed a null method', function() {
   expect(1);
 
   function onError(error) {
-    equal('You attempted to schedule an action in a queue (deferErrors) for a method doesn\'t exist', error.message);
+    equal('You attempted to schedule an action in a queue (deferErrors) for a method that doesn\'t exist', error.message);
   }
 
   var bb = new Backburner(['deferErrors'], {
@@ -78,7 +78,7 @@ test('throws when passed an undefined method', function() {
   expect(1);
 
   function onError(error) {
-    equal('You attempted to schedule an action in a queue (deferErrors) for a method doesn\'t exist', error.message);
+    equal('You attempted to schedule an action in a queue (deferErrors) for a method that doesn\'t exist', error.message);
   }
 
   var bb = new Backburner(['deferErrors'], {
@@ -94,7 +94,7 @@ test('throws when passed an method name that does not exists on the target', fun
   expect(1);
 
   function onError(error) {
-    equal('You attempted to schedule an action in a queue (deferErrors) for a method doesn\'t exist', error.message);
+    equal('You attempted to schedule an action in a queue (deferErrors) for a method that doesn\'t exist', error.message);
   }
 
   var bb = new Backburner(['deferErrors'], {

--- a/tests/defer-test.js
+++ b/tests/defer-test.js
@@ -38,6 +38,26 @@ test('when passed a target and method', function() {
   ok(functionWasCalled, 'function was called');
 });
 
+test('when passed a target and method name', function() {
+  expect(2);
+
+  var bb = new Backburner(['one']);
+  var functionWasCalled = false;
+  var targetObject = {
+    zomg: 'hi',
+    checkFunction: function() {
+      equal(this.zomg, 'hi', 'the target was properly set');
+      functionWasCalled = true;
+    }
+  };
+
+  bb.run(function() {
+    bb.defer('one', targetObject, 'checkFunction');
+  });
+
+  ok(functionWasCalled, 'function was called');
+});
+
 test('when passed a target, method, and arguments', function() {
   expect(5);
 


### PR DESCRIPTION
This PR adds checks for `defer` and `deferOnce` (and therefore, `schedule` and `scheduleOnce`) that throws an `Error` when the function scheduled does not exists.

Tests are present. I also added tests for supplying a method name instead of a function expression.

Please let me know if anything is missing :)

This should solve #131 and emberjs/ember.js#10800