### PR TITLE
Remove dead code used for dropping stalled timeouts

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -39,9 +39,6 @@ export default function Backburner(queueNames, options) {
   };
 }
 
-// ms of delay before we conclude a timeout was lost
-var TIMEOUT_STALLED_THRESHOLD = 1000;
-
 Backburner.prototype = {
   begin: function() {
     var options = this.options;
@@ -404,8 +401,6 @@ Backburner.prototype = {
       return fn;
     }
 
-    this._reinstallStalledTimerTimeout();
-
     // find position to insert
     var i = searchTimer(executeAt, this._timers);
 
@@ -598,21 +593,6 @@ Backburner.prototype = {
     }
     timers.splice(0, i);
     this._installTimerTimeout();
-  },
-
-  _reinstallStalledTimerTimeout: function () {
-    if (!this._timerTimeoutId) {
-      return;
-    }
-    // if we have a timer we should always have a this._timerTimeoutId
-    var minExpiresAt = this._timers[0];
-    var delay = now() - minExpiresAt;
-    // threshold of a second before we assume that the currently
-    // installed timeout will not run, so we don't constantly reinstall
-    // timeouts that are delayed but good still
-    if (delay < TIMEOUT_STALLED_THRESHOLD) {
-      return;
-    }
   },
 
   _reinstallTimerTimeout: function () {


### PR DESCRIPTION
Dead code found in https://github.com/ebryn/backburner.js/issues/156.