### PR TITLE
[breaking] remove needsIETryCatchFix

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -8,9 +8,7 @@ import {
   now
 } from './backburner/utils';
 
-import platform, {
-   needsIETryCatchFix
-} from './backburner/platform';
+import platform from './backburner/platform';
 
 import searchTimer from './backburner/binary-search';
 
@@ -622,14 +620,6 @@ Backburner.prototype = {
 Backburner.prototype.schedule = Backburner.prototype.defer;
 Backburner.prototype.scheduleOnce = Backburner.prototype.deferOnce;
 Backburner.prototype.later = Backburner.prototype.setTimeout;
-
-if (needsIETryCatchFix) {
-  var originalRun = Backburner.prototype.run;
-  Backburner.prototype.run = wrapInTryCatch(originalRun);
-
-  var originalEnd = Backburner.prototype.end;
-  Backburner.prototype.end = wrapInTryCatch(originalEnd);
-}
 
 function getOnError(options) {
   return options.onError || (options.onErrorTarget && options.onErrorTarget[options.onErrorMethod]);

--- a/lib/backburner/platform.js
+++ b/lib/backburner/platform.js
@@ -1,12 +1,3 @@
-// In IE 6-8, try/finally doesn't work without a catch.
-// Unfortunately, this is impossible to test for since wrapping it in a parent try/catch doesn't trigger the bug.
-// This tests for another broken try/catch behavior that only exhibits in the same versions of IE.
-export var needsIETryCatchFix = (function(e,x){
-  try{ x(); }
-  catch(e) { } // jshint ignore:line
-  return !!e;
-})();
-
 var platform;
 
 /* global self */


### PR DESCRIPTION
Ember doesn't support IE 6-8 anymore. If backburner wants to that's fine, but it'd be nice to get this out of the debugger when including breaking on uncaught exceptions.