### PR TITLE
[FEATURE] configurable setTimeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,19 @@
+---
 language: node_js
+
+cache:
+  directories:
+    - node_modules
+
+before_install:
+  - mkdir travis-phantomjs
+  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
+
+install:
+  - npm install
+
 script: npm test
 after_success:
 - npm build
@@ -9,3 +24,4 @@ env:
   - secure: Lo7dEbRFHNrQL29iUs88zFQyRNWcK7lnLIoPlBIUDiLOXamsUilxykAPmifIK34yFS4GqN+zv9mkcVEkieRQV5LlZgNd1RLJ5nDM6bkMSRM1K14K36EUy3ldU9Ld1d/sa5yx4cxJXqNRjfF/d+i7OTDQduLYmrFLhLPPu2HetbA=
   - secure: cAsSmFA77dBTgo7JHT3kcXlwAfilDoOwrVo3b77SHj64rWVUjB3xyaCWY+3gCoULTDD/fuEO80TWwzfV2sQGASvJyrSNLw3P7//Ym/dkHcTdQ3CfCagCf689/PfFTMM1+v6gZHSYcryJzRWkLolEgFlkU+lw4rwVlRjrKSwnRgQ=
   - secure: bNBRMlxWFRbAR04OI1SfwfYJis9KTm0C6O/xkAuMiardqJ6z+EpTXKSplAu6MlUM5VsiOON2ZNwo3bwmtshWhGiUhOVnjZCBtuVcJXyj/RQk9ug8A8pFKYn4o3Yn57H6o4tj/Gw3/NV5ocbw5MzRbgCSFkLbHl9lPDRTYyX2SwM=
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,4 @@
----
 language: node_js
-
-cache:
-  directories:
-    - node_modules
-
-before_install:
-  - mkdir travis-phantomjs
-  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
-  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
-
-install:
-  - npm install
-
 script: npm test
 after_success:
 - npm build
@@ -24,4 +9,3 @@ env:
   - secure: Lo7dEbRFHNrQL29iUs88zFQyRNWcK7lnLIoPlBIUDiLOXamsUilxykAPmifIK34yFS4GqN+zv9mkcVEkieRQV5LlZgNd1RLJ5nDM6bkMSRM1K14K36EUy3ldU9Ld1d/sa5yx4cxJXqNRjfF/d+i7OTDQduLYmrFLhLPPu2HetbA=
   - secure: cAsSmFA77dBTgo7JHT3kcXlwAfilDoOwrVo3b77SHj64rWVUjB3xyaCWY+3gCoULTDD/fuEO80TWwzfV2sQGASvJyrSNLw3P7//Ym/dkHcTdQ3CfCagCf689/PfFTMM1+v6gZHSYcryJzRWkLolEgFlkU+lw4rwVlRjrKSwnRgQ=
   - secure: bNBRMlxWFRbAR04OI1SfwfYJis9KTm0C6O/xkAuMiardqJ6z+EpTXKSplAu6MlUM5VsiOON2ZNwo3bwmtshWhGiUhOVnjZCBtuVcJXyj/RQk9ug8A8pFKYn4o3Yn57H6o4tj/Gw3/NV5ocbw5MzRbgCSFkLbHl9lPDRTYyX2SwM=
-

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -33,7 +33,7 @@ export default function Backburner(queueNames, options) {
   this._timerTimeoutId = undefined;
   this._timers = [];
 
-  this.timeoutFn = this.options.setTimeout || platform.setTimeout;
+  this.setTimeoutFn = this.options.setTimeout || platform.setTimeout;
   this.clearTimeoutFn = this.options.clearTimeout || platform.clearTimeout;
 
   var _this = this;
@@ -438,7 +438,7 @@ Backburner.prototype = {
     index = findThrottler(target, method, this._throttlers);
     if (index > -1) { return this._throttlers[index]; } // throttled
 
-    timer = this.timeoutFn(function() {
+    timer = this.setTimeoutFn(function() {
       if (!immediate) {
         backburner.run.apply(backburner, args);
       }
@@ -486,7 +486,7 @@ Backburner.prototype = {
       this.clearTimeoutFn(debouncee[2]);
     }
 
-    timer = this.timeoutFn(function() {
+    timer = this.setTimeoutFn(function() {
       if (!immediate) {
         backburner.run.apply(backburner, args);
       }
@@ -618,7 +618,7 @@ Backburner.prototype = {
     var minExpiresAt = this._timers[0];
     var n = now();
     var wait = Math.max(0, minExpiresAt - n);
-    this._timerTimeoutId = this.timeoutFn(this._boundRunExpiredTimers, wait);
+    this._timerTimeoutId = this.setTimeoutFn(this._boundRunExpiredTimers, wait);
   }
 };
 
@@ -632,7 +632,7 @@ function getOnError(options) {
 
 function createAutorun(backburner) {
   backburner.begin();
-  backburner._autorun = this.timeoutFn(function() {
+  backburner._autorun = backburner.setTimeoutFn(function() {
     backburner._autorun = null;
     backburner.end();
   });

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -26,14 +26,16 @@ export default function Backburner(queueNames, options) {
     begin: []
   };
 
-  this._clearItems = clearItems.bind(this);
+  var _this = this;
+  this._boundClearItems = function() {
+    clearItems();
+  };
 
   this._timerTimeoutId = undefined;
   this._timers = [];
 
   this.platform = this.options.platform || Platform;
 
-  var _this = this;
   this._boundRunExpiredTimers = function () {
     _this._runExpiredTimers();
   };
@@ -509,10 +511,10 @@ Backburner.prototype = {
   },
 
   cancelTimers: function() {
-    each(this._throttlers, this._clearItems);
+    each(this._throttlers, this._boundClearItems);
     this._throttlers = [];
 
-    each(this._debouncees, this._clearItems);
+    each(this._debouncees, this._boundClearItems);
     this._debouncees = [];
 
     this._clearTimerTimeout();

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -28,10 +28,13 @@ export default function Backburner(queueNames, options) {
     begin: []
   };
 
+  this._clearItems = clearItems.bind(this);
+
   this._timerTimeoutId = undefined;
   this._timers = [];
 
-  this.platformTimeout = options.setTimeout || platform.setTimeout;
+  this.timeoutFn = options.setTimeout || platform.setTimeout;
+  this.clearTimeoutFn = options.clearTimeout || platform.clearTimeout;
 
   var _this = this;
   this._boundRunExpiredTimers = function () {
@@ -435,7 +438,7 @@ Backburner.prototype = {
     index = findThrottler(target, method, this._throttlers);
     if (index > -1) { return this._throttlers[index]; } // throttled
 
-    timer = this.platformTimeout(function() {
+    timer = this.timeoutFn(function() {
       if (!immediate) {
         backburner.run.apply(backburner, args);
       }
@@ -480,10 +483,10 @@ Backburner.prototype = {
     if (index > -1) {
       debouncee = this._debouncees[index];
       this._debouncees.splice(index, 1);
-      clearTimeout(debouncee[2]);
+      this.clearTimeoutFn(debouncee[2]);
     }
 
-    timer = this.platformTimeout(function() {
+    timer = this.timeoutFn(function() {
       if (!immediate) {
         backburner.run.apply(backburner, args);
       }
@@ -509,17 +512,17 @@ Backburner.prototype = {
   },
 
   cancelTimers: function() {
-    each(this._throttlers, clearItems);
+    each(this._throttlers, this._clearItems);
     this._throttlers = [];
 
-    each(this._debouncees, clearItems);
+    each(this._debouncees, this._clearItems);
     this._debouncees = [];
 
     this._clearTimerTimeout();
     this._timers = [];
 
     if (this._autorun) {
-      clearTimeout(this._autorun);
+      this.clearTimeoutFn(this._autorun);
       this._autorun = null;
     }
   },
@@ -564,7 +567,7 @@ Backburner.prototype = {
 
       if (item[2] === timer[2]) {
         array.splice(index, 1);
-        clearTimeout(timer[2]);
+        this.clearTimeoutFn(timer[2]);
         return true;
       }
     }
@@ -604,7 +607,7 @@ Backburner.prototype = {
     if (!this._timerTimeoutId) {
       return;
     }
-    clearTimeout(this._timerTimeoutId);
+    this.clearTimeoutFn(this._timerTimeoutId);
     this._timerTimeoutId = undefined;
   },
 
@@ -615,7 +618,7 @@ Backburner.prototype = {
     var minExpiresAt = this._timers[0];
     var n = now();
     var wait = Math.max(0, minExpiresAt - n);
-    this._timerTimeoutId = this.platformTimeout(this._boundRunExpiredTimers, wait);
+    this._timerTimeoutId = this.timeoutFn(this._boundRunExpiredTimers, wait);
   }
 };
 
@@ -629,7 +632,7 @@ function getOnError(options) {
 
 function createAutorun(backburner) {
   backburner.begin();
-  backburner._autorun = this.platformTimeout(function() {
+  backburner._autorun = this.timeoutFn(function() {
     backburner._autorun = null;
     backburner.end();
   });
@@ -659,6 +662,6 @@ function findItem(target, method, collection) {
 }
 
 function clearItems(item) {
-  clearTimeout(item[2]);
+  this.clearTimeoutFn(item[2]);
 }
 

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -33,8 +33,8 @@ export default function Backburner(queueNames, options) {
   this._timerTimeoutId = undefined;
   this._timers = [];
 
-  this.timeoutFn = options.setTimeout || platform.setTimeout;
-  this.clearTimeoutFn = options.clearTimeout || platform.clearTimeout;
+  this.timeoutFn = this.options.setTimeout || platform.setTimeout;
+  this.clearTimeoutFn = this.options.clearTimeout || platform.clearTimeout;
 
   var _this = this;
   this._boundRunExpiredTimers = function () {

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -34,7 +34,7 @@ export default function Backburner(queueNames, options) {
   this._timerTimeoutId = undefined;
   this._timers = [];
 
-  this.platform = this.options.platform || Platform;
+  this._platform = this.options._platform || Platform;
 
   this._boundRunExpiredTimers = function () {
     _this._runExpiredTimers();
@@ -437,7 +437,7 @@ Backburner.prototype = {
     index = findThrottler(target, method, this._throttlers);
     if (index > -1) { return this._throttlers[index]; } // throttled
 
-    timer = this.platform.setTimeout(function() {
+    timer = this._platform.setTimeout(function() {
       if (!immediate) {
         backburner.run.apply(backburner, args);
       }
@@ -482,10 +482,10 @@ Backburner.prototype = {
     if (index > -1) {
       debouncee = this._debouncees[index];
       this._debouncees.splice(index, 1);
-      this.platform.clearTimeout(debouncee[2]);
+      this._platform.clearTimeout(debouncee[2]);
     }
 
-    timer = this.platform.setTimeout(function() {
+    timer = this._platform.setTimeout(function() {
       if (!immediate) {
         backburner.run.apply(backburner, args);
       }
@@ -521,7 +521,7 @@ Backburner.prototype = {
     this._timers = [];
 
     if (this._autorun) {
-      this.platform.clearTimeout(this._autorun);
+      this._platform.clearTimeout(this._autorun);
       this._autorun = null;
     }
   },
@@ -566,7 +566,7 @@ Backburner.prototype = {
 
       if (item[2] === timer[2]) {
         array.splice(index, 1);
-        this.platform.clearTimeout(timer[2]);
+        this._platform.clearTimeout(timer[2]);
         return true;
       }
     }
@@ -606,7 +606,7 @@ Backburner.prototype = {
     if (!this._timerTimeoutId) {
       return;
     }
-    this.platform.clearTimeout(this._timerTimeoutId);
+    this._platform.clearTimeout(this._timerTimeoutId);
     this._timerTimeoutId = undefined;
   },
 
@@ -617,7 +617,7 @@ Backburner.prototype = {
     var minExpiresAt = this._timers[0];
     var n = now();
     var wait = Math.max(0, minExpiresAt - n);
-    this._timerTimeoutId = this.platform.setTimeout(this._boundRunExpiredTimers, wait);
+    this._timerTimeoutId = this._platform.setTimeout(this._boundRunExpiredTimers, wait);
   }
 };
 
@@ -631,7 +631,7 @@ function getOnError(options) {
 
 function createAutorun(backburner) {
   backburner.begin();
-  backburner._autorun = backburner.platform.setTimeout(function() {
+  backburner._autorun = backburner._platform.setTimeout(function() {
     backburner._autorun = null;
     backburner.end();
   });
@@ -661,6 +661,6 @@ function findItem(target, method, collection) {
 }
 
 function clearItems(item) {
-  this.platform.clearTimeout(item[2]);
+  this._platform.clearTimeout(item[2]);
 }
 

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -8,10 +8,8 @@ import {
   now
 } from './backburner/utils';
 
-import platform from './backburner/platform';
-
+import Platform from './backburner/platform';
 import searchTimer from './backburner/binary-search';
-
 import DeferredActionQueues from './backburner/deferred-action-queues';
 
 export default function Backburner(queueNames, options) {
@@ -33,8 +31,7 @@ export default function Backburner(queueNames, options) {
   this._timerTimeoutId = undefined;
   this._timers = [];
 
-  this.setTimeoutFn = this.options.setTimeout || platform.setTimeout;
-  this.clearTimeoutFn = this.options.clearTimeout || platform.clearTimeout;
+  this.platform = this.options.platform || Platform;
 
   var _this = this;
   this._boundRunExpiredTimers = function () {
@@ -438,7 +435,7 @@ Backburner.prototype = {
     index = findThrottler(target, method, this._throttlers);
     if (index > -1) { return this._throttlers[index]; } // throttled
 
-    timer = this.setTimeoutFn(function() {
+    timer = this.platform.setTimeout(function() {
       if (!immediate) {
         backburner.run.apply(backburner, args);
       }
@@ -483,10 +480,10 @@ Backburner.prototype = {
     if (index > -1) {
       debouncee = this._debouncees[index];
       this._debouncees.splice(index, 1);
-      this.clearTimeoutFn(debouncee[2]);
+      this.platform.clearTimeout(debouncee[2]);
     }
 
-    timer = this.setTimeoutFn(function() {
+    timer = this.platform.setTimeout(function() {
       if (!immediate) {
         backburner.run.apply(backburner, args);
       }
@@ -522,7 +519,7 @@ Backburner.prototype = {
     this._timers = [];
 
     if (this._autorun) {
-      this.clearTimeoutFn(this._autorun);
+      this.platform.clearTimeout(this._autorun);
       this._autorun = null;
     }
   },
@@ -567,7 +564,7 @@ Backburner.prototype = {
 
       if (item[2] === timer[2]) {
         array.splice(index, 1);
-        this.clearTimeoutFn(timer[2]);
+        this.platform.clearTimeout(timer[2]);
         return true;
       }
     }
@@ -607,7 +604,7 @@ Backburner.prototype = {
     if (!this._timerTimeoutId) {
       return;
     }
-    this.clearTimeoutFn(this._timerTimeoutId);
+    this.platform.clearTimeout(this._timerTimeoutId);
     this._timerTimeoutId = undefined;
   },
 
@@ -618,7 +615,7 @@ Backburner.prototype = {
     var minExpiresAt = this._timers[0];
     var n = now();
     var wait = Math.max(0, minExpiresAt - n);
-    this._timerTimeoutId = this.setTimeoutFn(this._boundRunExpiredTimers, wait);
+    this._timerTimeoutId = this.platform.setTimeout(this._boundRunExpiredTimers, wait);
   }
 };
 
@@ -632,7 +629,7 @@ function getOnError(options) {
 
 function createAutorun(backburner) {
   backburner.begin();
-  backburner._autorun = backburner.setTimeoutFn(function() {
+  backburner._autorun = backburner.platform.setTimeout(function() {
     backburner._autorun = null;
     backburner.end();
   });
@@ -662,6 +659,6 @@ function findItem(target, method, collection) {
 }
 
 function clearItems(item) {
-  this.clearTimeoutFn(item[2]);
+  this.platform.clearTimeout(item[2]);
 }
 

--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -31,6 +31,8 @@ export default function Backburner(queueNames, options) {
   this._timerTimeoutId = undefined;
   this._timers = [];
 
+  this.platformTimeout = options.setTimeout || platform.setTimeout;
+
   var _this = this;
   this._boundRunExpiredTimers = function () {
     _this._runExpiredTimers();
@@ -433,7 +435,7 @@ Backburner.prototype = {
     index = findThrottler(target, method, this._throttlers);
     if (index > -1) { return this._throttlers[index]; } // throttled
 
-    timer = platform.setTimeout(function() {
+    timer = this.platformTimeout(function() {
       if (!immediate) {
         backburner.run.apply(backburner, args);
       }
@@ -481,7 +483,7 @@ Backburner.prototype = {
       clearTimeout(debouncee[2]);
     }
 
-    timer = platform.setTimeout(function() {
+    timer = this.platformTimeout(function() {
       if (!immediate) {
         backburner.run.apply(backburner, args);
       }
@@ -613,7 +615,7 @@ Backburner.prototype = {
     var minExpiresAt = this._timers[0];
     var n = now();
     var wait = Math.max(0, minExpiresAt - n);
-    this._timerTimeoutId = setTimeout(this._boundRunExpiredTimers, wait);
+    this._timerTimeoutId = this.platformTimeout(this._boundRunExpiredTimers, wait);
   }
 };
 
@@ -627,7 +629,7 @@ function getOnError(options) {
 
 function createAutorun(backburner) {
   backburner.begin();
-  backburner._autorun = platform.setTimeout(function() {
+  backburner._autorun = this.platformTimeout(function() {
     backburner._autorun = null;
     backburner.end();
   });

--- a/lib/backburner/platform.js
+++ b/lib/backburner/platform.js
@@ -3,10 +3,10 @@ function ifDefined(o) {
   return typeof o !== 'undefined' ? o : false;
 }
 
-var platform = ifDefined(self) || ifDefined(global) || ifDefined(window);
+var GlobalContext = ifDefined(self) || ifDefined(global) || ifDefined(window);
 
-if (!platform) {
+if (!GlobalContext) {
   throw new Error('no global: `self` nor `global` nor `window` was found');
 }
 
-export default platform;
+export default GlobalContext;

--- a/lib/backburner/platform.js
+++ b/lib/backburner/platform.js
@@ -1,14 +1,12 @@
-var platform;
+/* global self, global, window */
+function ifDefined(o) {
+  return typeof o !== 'undefined' ? o : false;
+}
 
-/* global self */
-if (typeof self === 'object') {
-  platform = self;
+var platform = ifDefined(self) || ifDefined(global) || ifDefined(window);
 
-/* global global */
-} else if (typeof global === 'object') {
-  platform = global;
-} else {
-  throw new Error('no global: `self` or `global` found');
+if (!platform) {
+  throw new Error('no global: `self` nor `global` nor `window` was found');
 }
 
 export default platform;

--- a/tests/configurable-timeout-test.js
+++ b/tests/configurable-timeout-test.js
@@ -13,10 +13,10 @@ test('We can configure a custom platform', function() {
   };
 
   var bb = new Backburner(['one'], {
-    platform: fakePlatform
+    _platform: fakePlatform
   });
 
-  ok(bb.options.platform.isFakePlatform, 'We can pass in a custom platform');
+  ok(bb.options._platform.isFakePlatform, 'We can pass in a custom platform');
 });
 
 test('We can use a custom setTimeout', function() {
@@ -24,7 +24,7 @@ test('We can use a custom setTimeout', function() {
 
   var customTimeoutWasUsed = false;
   var bb = new Backburner(['one'], {
-    platform: {
+    _platform: {
       setTimeout: function customSetTimeout(method, wait) {
         customTimeoutWasUsed = true;
         return GlobalContext.setTimeout(method, wait);
@@ -39,7 +39,7 @@ test('We can use a custom setTimeout', function() {
   stop();
   bb.deferOnce('one', function() {
     start();
-    ok(bb.options.platform.isFakePlatform, 'we are using the fake platform');
+    ok(bb.options._platform.isFakePlatform, 'we are using the fake platform');
     ok(customTimeoutWasUsed , 'custom setTimeout was used');
   });
 });
@@ -51,7 +51,7 @@ test('We can use a custom clearTimeout', function() {
   var functionWasCalled = false;
   var customClearTimeoutWasUsed = false;
   var bb = new Backburner(['one'], {
-    platform: {
+    _platform: {
       setTimeout: function customSetTimeout(method, wait) {
         return GlobalContext.setTimeout(method, wait);
       },

--- a/tests/configurable-timeout-test.js
+++ b/tests/configurable-timeout-test.js
@@ -1,0 +1,76 @@
+import Backburner from '../lib/backburner';
+import GlobalContext from '../lib/backburner/platform';
+
+module('configurable platform.setTimeout');
+
+test('We can configure a custom platform', function() {
+  expect(1);
+
+  var fakePlatform = {
+    setTimeout: function() {},
+    clearTimeout: function() {},
+    isFakePlatform: true
+  };
+
+  var bb = new Backburner(['one'], {
+    platform: fakePlatform
+  });
+
+  ok(bb.options.platform.isFakePlatform, 'We can pass in a custom platform');
+});
+
+test('We can use a custom setTimeout', function() {
+  expect(2);
+
+  var customTimeoutWasUsed = false;
+  var bb = new Backburner(['one'], {
+    platform: {
+      setTimeout: function customSetTimeout(method, wait) {
+        customTimeoutWasUsed = true;
+        return GlobalContext.setTimeout(method, wait);
+      },
+      clearTimeout: function customClearTimeout(timer) {
+        return GlobalContext.clearTimeout(timer);
+      },
+      isFakePlatform: true
+    }
+  });
+
+  stop();
+  bb.deferOnce('one', function() {
+    start();
+    ok(bb.options.platform.isFakePlatform, 'we are using the fake platform');
+    ok(customTimeoutWasUsed , 'custom setTimeout was used');
+  });
+});
+
+
+test('We can use a custom clearTimeout', function() {
+  expect(2);
+
+  var functionWasCalled = false;
+  var customClearTimeoutWasUsed = false;
+  var bb = new Backburner(['one'], {
+    platform: {
+      setTimeout: function customSetTimeout(method, wait) {
+        return GlobalContext.setTimeout(method, wait);
+      },
+      clearTimeout: function customClearTimeout(timer) {
+        customClearTimeoutWasUsed = true;
+        return GlobalContext.clearTimeout(timer);
+      }
+    }
+  });
+
+  bb.deferOnce('one', function() {
+    functionWasCalled = true;
+  });
+  bb.cancelTimers();
+
+  bb.run(function() {
+    bb.deferOnce('one', function() {
+      ok(!functionWasCalled, 'function was not called');
+      ok(customClearTimeoutWasUsed, 'custom clearTimeout was used');
+    });
+  });
+});

--- a/tests/index.html
+++ b/tests/index.html
@@ -16,7 +16,7 @@
   <script>
     Object.keys(require.entries).filter(function(a) {
       return /-test$/.test(a);
-    }).map(require)
+    }).map(require);
   </script>
 </body>
 </html>


### PR DESCRIPTION
This PR enables the `setTimeout` instance used by `backburner.js` to be configurable, by modifying the use of `platform` to also be configurable.

The benefit of this is that users can easily switch out the `setTimeout` implementation for smarter implementations built on `requestAnimationFrame` or `requestIdleCallback`.

An example use case of this is `ember-run-raf`, which has enabled using backburner with `requestAnimationFrame` via a global override of `setTimeout`.  In using backburner with requestAnimationFrame in this way within Ember applications, nothing but positive results have been noted, with the exception of an issue arising `socket.io`, which uses `setTimeout` during it's socket keep-alive sequence.  Work scheduled in `requestAnimationFrame` is paused while tabs are inactive, leading `socket.io` to close the socket.

With this change, the override in ember-run-raf will no longer need to be global, allowing applications which need to use setTimeout for background tasks to continue functioning properly.