### PR TITLE
Remove unused `wrapInTryCatch`

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -4,7 +4,6 @@ import {
   isFunction,
   isNumber,
   isCoercableNumber,
-  wrapInTryCatch,
   now
 } from './backburner/utils';
 

--- a/lib/backburner/utils.js
+++ b/lib/backburner/utils.js
@@ -25,13 +25,3 @@ export function isNumber(suspect) {
 export function isCoercableNumber(number) {
   return isNumber(number) || NUMBER.test(number);
 }
-
-export function wrapInTryCatch(func) {
-  return function () {
-    try {
-      return func.apply(this, arguments);
-    } catch (e) {
-      throw e;
-    }
-  };
-}


### PR DESCRIPTION
In favor of 0742e518 introduced by https://github.com/ebryn/backburner.js/pull/162.