### PR TITLE
[BUGFIX] Fix ReferenceError in global context detection

### DIFF
--- a/lib/backburner/platform.js
+++ b/lib/backburner/platform.js
@@ -1,12 +1,18 @@
-/* global self, global, window */
-function ifDefined(o) {
-  return typeof o !== 'undefined' ? o : false;
-}
+var GlobalContext;
 
-var GlobalContext = ifDefined(self) || ifDefined(global) || ifDefined(window);
+/* global self */
+if (typeof self === 'object') {
+  GlobalContext = self;
 
-if (!GlobalContext) {
-  throw new Error('no global: `self` nor `global` nor `window` was found');
+/* global global */
+} else if (typeof global === 'object') {
+  GlobalContext = global;
+
+/* global window */
+} else if (typeof window === 'object') {
+  GlobalContext = window;
+} else {
+  throw new Error('no global: `self`, `global` nor `window` was found');
 }
 
 export default GlobalContext;


### PR DESCRIPTION
When undefined variable is referenced in global context detection, it throws `ReferenceError`.