### PR TITLE
[CLEARITEMS]: argument item taken out...tests still pass

### DIFF
--- a/lib/backburner.js
+++ b/lib/backburner.js
@@ -658,7 +658,7 @@ function findItem(target, method, collection) {
   return index;
 }
 
-function clearItems(item) {
-  this._platform.clearTimeout(item[2]);
+function clearItems() {
+  this._platform.clearTimeout();
 }
 


### PR DESCRIPTION
Not really a pull request, but might be.  Having some troubles with my test run after upgrading to Ember 2.4.0.beta-3 which I suspect might be this commit https://github.com/emberjs/ember.js/pull/12930.

In acceptance test land, running a simple `visit` w/ `assert.equal(1,1)` acts like I put a return pauseTest after the visit.  Specifically get stuck somewhere here where my breakpoint is:

<img width="768" alt="screen shot 2016-04-29 at 11 41 08 pm" src="https://cloud.githubusercontent.com/assets/7374640/14943208/9371c9c6-0f87-11e6-8473-3a9ec50c1cc1.png">


I'm using a timemachine freeze in order to get a consistent date in my test run. Commenting this import out will allow my test run to go through.  https://github.com/toranb/freeze-time-testing-example/blob/master/vendor/timemachine.js.  Timemachine might be related to the second part of that commit (https://github.com/emberjs/ember.js/pull/12930), but I first wanted to tackle the below question.


So, in this commit, was there meant to be an argument to `clearItems`?  Backburner tests still pass if I remove the `item` argument.  It looks like it is called here: https://github.com/snewcomer/backburner.js/blob/master/lib/backburner.js#L29


