### PR TITLE
Add basic benchmarks for cancel.

### DIFF
--- a/bench/benches/cancel.js
+++ b/bench/benches/cancel.js
@@ -1,0 +1,11 @@
+var Backburner = require('../../dist/backburner');
+
+var backburner = new Backburner(["sync", "actions", "routerTransitions", "render", "afterRender", "destroy", "rsvpAfter"]);
+
+module.exports = [{
+  name: 'Cancel - no timer',
+
+  fn: function() {
+    backburner.cancel(null);
+  }
+}];

--- a/bench/benches/schedule-cancel.js
+++ b/bench/benches/schedule-cancel.js
@@ -1,0 +1,114 @@
+var Backburner = require('../../dist/backburner');
+
+function sharedSetup() {
+  var backburner = new this.Backburner(["sync", "actions", "routerTransitions", "render", "afterRender", "destroy", "rsvpAfter"]);
+
+  var target = {
+    someMethod: function() { }
+  };
+}
+
+module.exports = [{
+  name: 'Schedule & Cancel - function',
+
+  Backburner: Backburner,
+
+  setup: sharedSetup,
+
+  fn: function() {
+    var timer = backburner.schedule('render', function() {
+      // no body
+    });
+    backburner.cancel(timer);
+  }
+}, {
+  name: 'Schedule & Cancel - target, function',
+
+  Backburner: Backburner,
+
+  setup: sharedSetup,
+
+  fn: function() {
+    var timer = backburner.schedule('render', target, function() {
+      // no body
+    });
+    backburner.cancel(timer);
+  }
+}, {
+  name: 'Schedule & Cancel - target, string method name',
+
+  Backburner: Backburner,
+
+  setup: sharedSetup,
+
+  fn: function() {
+    var timer = backburner.schedule('render', target, 'someMethod');
+    backburner.cancel(timer);
+  }
+}, {
+  name: 'Schedule & Cancel - target, string method name, 1 argument',
+
+  Backburner: Backburner,
+
+  setup: sharedSetup,
+
+  fn: function() {
+    var timer = backburner.schedule('render', target, 'someMethod', 'foo');
+    backburner.cancel(timer);
+  }
+}, {
+  name: 'Schedule & Cancel - target, string method name, 2 arguments',
+
+  Backburner: Backburner,
+
+  setup: sharedSetup,
+
+  fn: function() {
+    var timer = backburner.schedule('render', target, 'someMethod', 'foo', 'bar');
+    backburner.cancel(timer);
+  }
+}, {
+  name: 'Schedule & Cancel - prescheduled, same queue - target, string method name',
+
+  Backburner: Backburner,
+
+  setup: function() {
+    var backburner = new this.Backburner(["sync", "actions", "routerTransitions", "render", "afterRender", "destroy", "rsvpAfter"]);
+
+    var target = {
+      someMethod: function() { }
+    };
+
+    var prescheduleSetupIterations = 100;
+    while (prescheduleSetupIterations--) {
+      backburner.schedule('render', function() { });
+    }
+  },
+
+  fn: function() {
+    var timer = backburner.schedule('render', target, 'someMethod');
+    backburner.cancel(timer);
+  }
+}, {
+  name: 'Schedule & Cancel - prescheduled, separate queue - target, string method name',
+
+  Backburner: Backburner,
+
+  setup: function() {
+    var backburner = new this.Backburner(["sync", "actions", "routerTransitions", "render", "afterRender", "destroy", "rsvpAfter"]);
+
+    var target = {
+      someMethod: function() { }
+    };
+
+    var prescheduleSetupIterations = 100;
+    while (prescheduleSetupIterations--) {
+      backburner.schedule('actions', function() { });
+    }
+  },
+
+  fn: function() {
+    var timer = backburner.schedule('render', target, 'someMethod');
+    backburner.cancel(timer);
+  }
+}];

--- a/bench/index.js
+++ b/bench/index.js
@@ -1,0 +1,15 @@
+var glob = require('glob');
+var path = require('path');
+var bench = require('do-you-even-bench');
+
+var suites = [];
+glob.sync( './bench/benches/*.js' ).forEach(function(file) {
+  var exported = require( path.resolve( file ) );
+  if (Array.isArray(exported)) {
+    suites = suites.concat(exported);
+  } else {
+    suites.push(exported);
+  }
+});
+
+bench(suites);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prepublish": "ember build --environment=production",
     "test": "ember test",
     "test:server": "ember test --server",
-    "lint": "jshint lib/*"
+    "lint": "jshint lib/*",
+    "bench": "ember build && node ./bench/index.js"
   },
   "author": "Erik Bryn",
   "license": "MIT",
@@ -22,7 +23,9 @@
     "broccoli-merge-trees": "^1.1.4",
     "broccoli-plugin": "^1.2.1",
     "broccoli-rollup": "^1.0.2",
+    "do-you-even-bench": "^1.0.2",
     "ember-cli": "2.7.0",
+    "glob": "^7.1.1",
     "jshint": "^2.9.3",
     "loader.js": "^3.3.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
In preparation for playing with `run.cancel` performance I figured I'd add some benchmarks to be able to quickly judge before/after.

Current output of `npm run bench` is:

```
  Cancel - no timer ............................................................... 27,841,173.65 op/s
  Schedule & Cancel - function ..................................................... 3,261,977.70 op/s
  Schedule & Cancel - target, function ............................................. 3,226,585.72 op/s
  Schedule & Cancel - target, string method name ................................... 3,173,040.97 op/s
  Schedule & Cancel - target, string method name, 1 argument ....................... 2,832,891.59 op/s
  Schedule & Cancel - target, string method name, 2 arguments ...................... 2,910,038.74 op/s
  Schedule & Cancel - prescheduled, same queue - target, string method name ........ 1,095,261.55 op/s
  Schedule & Cancel - prescheduled, separate queue - target, string method name .... 3,238,070.56 op/s
```
