### PR TITLE
Make `now` configurable so time can freeze outside of backburner

### DIFF
--- a/lib/backburner/index.js
+++ b/lib/backburner/index.js
@@ -3,7 +3,8 @@ import {
   isString,
   isFunction,
   isNumber,
-  isCoercableNumber
+  isCoercableNumber,
+  now
 } from './utils';
 
 import searchTimer from './binary-search';
@@ -379,7 +380,7 @@ Backburner.prototype = {
       }
     }
 
-    var executeAt = Date.now() + parseInt(wait !== wait ? 0 : wait, 10);
+    var executeAt = now() + parseInt(wait !== wait ? 0 : wait, 10);
 
     if (isString(method)) {
       method = target[method];
@@ -586,7 +587,7 @@ Backburner.prototype = {
   },
 
   _scheduleExpiredTimers: function () {
-    var n = Date.now();
+    var n = now();
     var timers = this._timers;
     var i = 0;
     var l = timers.length;
@@ -621,7 +622,7 @@ Backburner.prototype = {
       return;
     }
     var minExpiresAt = this._timers[0];
-    var n = Date.now();
+    var n = now();
     var wait = Math.max(0, minExpiresAt - n);
     this._timerTimeoutId = this._platform.setTimeout(this._boundRunExpiredTimers, wait);
   }

--- a/lib/backburner/utils.js
+++ b/lib/backburner/utils.js
@@ -1,5 +1,7 @@
 var NUMBER = /\d+/;
 
+export var now = Date.now;
+
 export function each(collection, callback) {
   for (var i = 0; i < collection.length; i++) {
     callback(collection[i]);

--- a/tests/set-timeout-test.js
+++ b/tests/set-timeout-test.js
@@ -1,9 +1,11 @@
 import Backburner from 'backburner';
 
+var originalDateNow = Date.now;
 var originalDateValueOf = Date.prototype.valueOf;
 
 module('setTimeout',{
   teardown: function(){
+    Date.now = originalDateNow;
     Date.prototype.valueOf = originalDateValueOf;
   }
 });
@@ -50,6 +52,21 @@ test('setTimeout', function() {
       ok(true, 'Another later will execute correctly');
     }, 1);
   }, 20);
+});
+
+test('setTimeout can continue when `Date.now` is monkey-patched', function() {
+  expect(1);
+
+  var arbitraryTime = +new Date();
+  var bb = new Backburner(['one']);
+
+  Date.now = function() { return arbitraryTime; };
+
+  stop();
+  bb.setTimeout(function() {
+    start();
+    ok(true);
+  }, 1);
 });
 
 var bb;


### PR DESCRIPTION
The main purpose of this PR is to initiate a discussion around the problem of freezing time while using Backburner. With PR #166 (and [#12941](https://github.com/emberjs/ember.js/pull/12941) in Ember) we lost the ability to monkey-patch `Date.now` without stopping Backburner from running. The use case for freezing time is in testing. Being able to peg time to an arbitrary point while testing time-related things is invaluable in preventing non-determinism.

My proposal is to somehow make the concept of "now" configurable and this PR is my first pass at it, mostly a proof-of-concept. It would also be nice to have an explicit public API (as opposed to doing something like `Ember.run.backburner._platform = …` which makes me feel like I'm being bad–even just removing the underscore would be nice).

Looking forward to hearing y'alls thoughts. Thanks!