### PR TITLE
[bugfix] Prevent an unhandled error from being thrown when throttle and cancelTimers were used jointly

### DIFF
--- a/lib/backburner/index.js
+++ b/lib/backburner/index.js
@@ -28,7 +28,7 @@ export default function Backburner(queueNames, options) {
 
   var _this = this;
   this._boundClearItems = function() {
-    clearItems();
+    clearItems.apply(_this, arguments);
   };
 
   this._timerTimeoutId = undefined;

--- a/tests/throttle-test.js
+++ b/tests/throttle-test.js
@@ -104,6 +104,24 @@ test('throttle', function() {
   }, 180);
 });
 
+test('throttle with cancelTimers', function() {
+  expect(1);
+
+  var count = 0;
+  var bb = new Backburner(['zomg']);
+
+  // Throttle a no-op 10ms
+  bb.throttle(null, function(){ /* no-op */ }, 10, false);
+
+  try {
+    bb.cancelTimers();
+  } catch(e) {
+    count++;
+  }
+
+  equal(count, 0, 'calling cancelTimers while something is being throttled does not throw an error');
+});
+
 test('throttle leading edge', function() {
   expect(10);
 


### PR DESCRIPTION
Provides a fix for https://github.com/ebryn/backburner.js/issues/184 (read that issue for details on the problem) and also, a new test validating the fix.